### PR TITLE
Updated the redash/query_runner/pg.py PostgreSQL _get_tables method

### DIFF
--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -221,7 +221,8 @@ class PostgreSQL(BaseSQLQueryRunner):
         AND a.attnum > 0
         AND NOT a.attisdropped
         WHERE c.relkind IN ('m', 'f', 'p')
-
+        AND has_schema_privilege(s.nspname, 'usage')
+        AND has_table_privilege(s.nspname || '.' || c.relname, 'select')
         UNION
 
         SELECT table_schema,


### PR DESCRIPTION
Added the following conditions to the where clause in the query in the _get_tables method:
AND has_schema_privilege(s.nspname, 'usage')
AND has_table_privilege(s.nspname || '.' || c.relname, 'select')

## What type of PR is this? 

- [x] Bug Fix


## Description
Add a check to ensure user has usage on the schema before checking if they have select on the table when building postgres schema info.

## How is this tested?

- [x] Manually

Tested query update against postgres instance